### PR TITLE
fix: cambiar propiedad word-wrap en el titulo para que el sitio escale bien en móvil

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -2,10 +2,12 @@
   h1 {
     font-size: 50px;
     letter-spacing: 8px;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
+
   p {
     color: white;
-    // font-weight: 400;
   }
 }
 


### PR DESCRIPTION
El título a veces era más grande que el viewport, por lo que se cambió la propiedad word-wrap para que escale correctamente.

**Antes**
<img width="359" height="758" alt="image" src="https://github.com/user-attachments/assets/e275911c-5535-4329-8624-0a708a866e6a" />

**Después**
<img width="359" height="758" alt="image" src="https://github.com/user-attachments/assets/3303f755-74a7-45d9-aa2b-ff0f9a3b282d" />
