### PR TITLE
fix: agregar word breakpoint para separar correctamente el título

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -2,8 +2,8 @@
   h1 {
     font-size: 50px;
     letter-spacing: 8px;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
+    // word-wrap: break-word;
+    // overflow-wrap: break-word;
   }
 
   p {

--- a/content/spanish/_index.md
+++ b/content/spanish/_index.md
@@ -4,7 +4,7 @@ banner:
   enable: true
   bg_image: "images/AURORA-Community.png"
   bg_overlay: true
-  title: "Aurora STEAM<br/>Guatemala"
+  title: "Aurora STEAM<br/>Guate<wbr />mala"
   content: "Este 21 de marzo celebremos juntas el poder de las mujeres en STEAM en nuestro evento IWD 2026."
   button:
     enable: true


### PR DESCRIPTION
Agregar un word breakpoint en el título para que separe correctamente la palabra "Guatemala".

**Antes:**
<img width="436" height="800" alt="image" src="https://github.com/user-attachments/assets/5a9609f5-4fda-46bb-983c-8547de7be8f7" />

**Después**
<img width="436" height="800" alt="image" src="https://github.com/user-attachments/assets/3b6c1aa8-dfc8-41dd-927f-c5ecc2442121" />
