### PR TITLE
fix: parámetros de conf release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "aurora-website"
+      "package-name": "aurorasteamgt-website",
+      "include-component-in-tag": false
     }
   },
   "pull-request-title-pattern": "ci: [bot] release ${version}",


### PR DESCRIPTION
Se corrigieron parámetros de configuración de release-please:
1. `package-name: aurorasteamgt-website` se corrigió al valor ya usado anteriormente.
2. `include-component-in-tag: false` para que los tags se busquen con formato `vX.X.X` en vez de `aurorasteamgt-website-vX.X.X`